### PR TITLE
Displaying sites as buttons in description

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -63,6 +63,7 @@ function renderDescription(containerNode, description) {
     if(!description)
         return;
     let dlBuilder = null;
+    let enteredSites = false;
 
     for (const entry of description) {
         if (entry instanceof Object) {
@@ -79,7 +80,12 @@ function renderDescription(containerNode, description) {
                 Object.entries(entry.value).forEach(([k, v])=>subDlBuilder.addEntry(k, v.toString()));
                 value = [subDlBuilder.build()];
             } else {
-                value = entry.value;
+                if (enteredSites) {
+                    let buttonBuilder = new HTMLHelpers.ButtonBuilder(entry.value.toString());
+                    value = buttonBuilder.build();
+                } else {
+                    value = entry.value;
+                }
             }
             dlBuilder.addEntry(entry.key, value);
         } else {
@@ -89,6 +95,11 @@ function renderDescription(containerNode, description) {
             }
             if (typeof entry == "string") {
                 if (entry.startsWith("# ")) {
+                    if (entry == "# Sites") {
+                        enteredSites = true;
+                    } else {
+                        enteredSites = false;
+                    }
                     let h = document.createElement("h4");
                     h.innerText = entry.substring(2).trim();
                     containerNode.appendChild(h);

--- a/src/htmlhelpers.js
+++ b/src/htmlhelpers.js
@@ -1,3 +1,17 @@
+export class ButtonBuilder {
+    constructor(value) {
+        this.button = document.createElement("button");
+        this.button.textContent = value;
+    }
+
+    /**
+     * @returns {HTMLButtonElement}
+     */
+    build() {
+        return this.button;
+    }
+};
+
 export class DefinitionListBuilder {
     constructor(attrs={}) {
         this.dl = document.createElement("dl");


### PR DESCRIPTION
Hi Karol,
The following is the summary of this draft PR
1) Understood that "description" contains the grid position information, site information and for some tiles Pin information as well 
2)In order to display the contents of a site, the site information should be read from the .json and should be made as a clickable button which when clicked, opens up the sub grid
 3) In this draft PR, successfully read the .json for site information and made the same as clickable buttons (This is the first one requirement as specified in the doc)
 
 Currently working on
 1) The action to take place when the button is clicked
 2) The dynamic updation of links