### PR TITLE
Add support for omitting empty rows/columns

### DIFF
--- a/utils/datafilegen/datafile.py
+++ b/utils/datafilegen/datafile.py
@@ -80,8 +80,8 @@ class SdbvGridCells:
 class SdbvGrid:
     def __init__(self):
         self.name = None
-        self.colsRange = [0, 0]
-        self.rowsRange = [0, 0]
+        self.colsRange = [[0, 0]]
+        self.rowsRange = [[0, 0]]
         self.rowHeaders = None
         self.colHeaders = None
         self.cells = SdbvGridCells()

--- a/utils/datafilegen/prjxraydbconverter
+++ b/utils/datafilegen/prjxraydbconverter
@@ -132,8 +132,8 @@ class PrjxrayDbConverter:
 
             grid.cells.addCell(cell)
 
-        grid.colsRange = cols_range
-        grid.rowsRange = rows_range
+        grid.colsRange = [cols_range]
+        grid.rowsRange = [rows_range]
 
         self.data_file.grids[""] = grid
 


### PR DESCRIPTION
Currently it is only possible to pass rows in format `rowsRange: [first, last]`. This PR introduces a more versatile way of passing rows so it can now take variants that contain both ranges and single rows mixed up e.g.:
```
rows: [
  [1, 10],
  11,
  14,
  [16, 19]
]
```
which would produce a visualization of rows:
```
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 16, 17, 18, 19]
```
A `rows` keyword can be replaced with `rowsRange`. It's added to make it more clear when looking at the json file itself since a generated one from [logs2vis.py](https://github.com/antmicro/rowhammer-tester/blob/master/rowhammer_tester/scripts/logs2vis.py) will contain `rows` for a mixup of rows and ranges and it will contain `rowsRange` for a single range.

`json` can be generated using antmicro/rowhammer-tester/pull/131

**This change affects `cols` and `colsRange` as well.**